### PR TITLE
Fix SVG retrieval for languages with country code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.9
+
+* Fixed SVG retrieval for languages with country code that don't have a match in SVG assets
+
 ## 0.0.8
 
 * Fixed SVG in all supported locales

--- a/lib/utils/locale_utils.dart
+++ b/lib/utils/locale_utils.dart
@@ -11,11 +11,15 @@ extension LocaleExtensions on Locale {
   bool _existsInAssets() => validAssetLocaleSet.contains(this);
 
   Locale _getFallbackLocale() {
+    final primaryLocale = Locale(languageCode);
+    if (primaryLocale._existsInAssets()) {
+      return primaryLocale;
+    }
     switch (languageCode) {
       case 'fr':
         return const Locale('fr', 'FR');
       case 'en':
-        return const Locale('en', 'GB');
+        return const Locale('en', 'US');
       case 'es':
         return const Locale('es', 'ES');
       case 'zh':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_wallet
 description: A Flutter Google Wallet Plugin
-version: 0.0.8
+version: 0.0.9
 homepage: https://github.com/voyages-sncf-technologies/flutter_google_wallet
 
 environment:

--- a/test/locale_utils_test.dart
+++ b/test/locale_utils_test.dart
@@ -6,8 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   test('GIVEN locale THEN toAssetPrefix() returns asset prefix', () async {
     expect(const Locale('fr').toAssetPrefix(), 'frFR');
+    expect(const Locale('fr', 'CA').toAssetPrefix(), 'frCA');
     expect(const Locale('de').toAssetPrefix(), 'de');
-    expect(const Locale('en').toAssetPrefix(), 'enGB');
+    expect(const Locale('de', 'DE').toAssetPrefix(), 'de');
+    expect(const Locale('en').toAssetPrefix(), 'enUS');
     expect(const Locale('it').toAssetPrefix(), 'it');
     expect(const Locale('nl').toAssetPrefix(), 'nl');
   });


### PR DESCRIPTION
Fix SVG retrieval for languages with country code that don't have a match in SVG files