### PR TITLE
Bumped intl version to ^0.19.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_svg: ^2.0.5
   flutter_localizations:
     sdk: flutter
-  intl: ^0.18.0
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pr updates the intl package to version 0.19.0 since the current version of flutter_localizations has been pinned to 0.19.0